### PR TITLE
FEAT - Add Multi quote

### DIFF
--- a/commands/multi_quote.go
+++ b/commands/multi_quote.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"log/slog"
+
+	"github.com/Coop25/quotebot-go/accessors/postgres"
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+)
+
+var MultiQuoteCommandCreate = discord.SlashCommandCreate{
+	Name:        "multi-quote",
+	Description: "Get a random quote",
+	Options: []discord.ApplicationCommandOption{
+		discord.ApplicationCommandOptionBool{
+			Name:        "ephemeral",
+			Description: "If the response should only be visible to you",
+			Required:    true,
+		},
+		discord.ApplicationCommandOptionInt{
+			Name:        "count",
+			Description: "The number of quotes to return",
+			Required:    true,
+		},
+		discord.ApplicationCommandOptionBool{
+			Name:        "show-id",
+			Description: "If the quote id should be shown",
+			Required:    false,
+		},
+	},
+}
+
+func SendRandomMultiQuote(event *events.ApplicationCommandInteractionCreate, pg postgres.PostgresAccessor) {
+	data := event.SlashCommandInteractionData()
+	ephemeral := data.Bool("ephemeral")
+	showID := data.Bool("show-id")
+	count := int(data.Int("count"))
+	quotes, err := getQuotesUntilLimit(event, pg, count, showID)
+	if err != nil {
+		slog.Error("error on getting random quote", slog.Any("err", err))
+		return
+	}
+
+	err = event.CreateMessage(discord.NewMessageCreateBuilder().
+		SetContent(quotes).
+		SetEphemeral(ephemeral).
+		Build(),
+	)
+	if err != nil {
+		slog.Error("error on sending response", slog.Any("err", err))
+	}
+}
+
+func getQuotesUntilLimit(event *events.ApplicationCommandInteractionCreate, pg postgres.PostgresAccessor, count int, isShowID bool) (string, error) {
+	data := event.SlashCommandInteractionData()
+	quotes := ""
+	quoteIDs := ""
+	for i := 0; i < count; i++ {
+		message, err := pg.GetRandomQuote(data.GuildID().String())
+		if err != nil {
+			slog.Error("error on getting random quote", slog.Any("err", err))
+			return "", err
+		}
+		quoteIDs += "> **Quote ID: **" + message.ID.String() + "\n"
+		if isShowID {
+			if len(quotes+quoteIDs+"\n\n"+message.Quote) < 2000 {
+				quotes += message.Quote + "\n"
+				if len(quotes+quoteIDs+"\n")+100 > 2000 {
+					quotes = quoteIDs + "\n" + quotes
+					slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+					break
+				}
+			} else {
+				quotes = quoteIDs + "\n" + quotes
+				slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+				break
+			}
+		} else {
+			if len(quotes+"\n"+message.Quote) < 2000 {
+				quotes += message.Quote + "\n"
+			} else {
+				slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+				break
+			}
+		}
+	}
+
+	return quotes, nil
+}

--- a/commands/quote.go
+++ b/commands/quote.go
@@ -36,7 +36,7 @@ func SendRandomQuote(event *events.ApplicationCommandInteractionCreate, pg postg
 	showID := data.Bool("show-id")
 
 	if showID {
-		message.Quote = message.Quote + " \nQuote Id: " + message.ID.String()
+		message.Quote = message.Quote + " \n> Quote Id: " + message.ID.String()
 	}
 
 	err = event.CreateMessage(discord.NewMessageCreateBuilder().

--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ import (
 
 var (
 	commandHandlers = map[string]func(*events.ApplicationCommandInteractionCreate, postgres.PostgresAccessor){
-		commands.QuoteCommandCreate.Name:    commands.SendRandomQuote,
-		commands.AddQuoteCommandCreate.Name: commands.SendAddQuote,
+		commands.QuoteCommandCreate.Name:      commands.SendRandomQuote,
+		commands.AddQuoteCommandCreate.Name:   commands.SendAddQuote,
+		commands.MultiQuoteCommandCreate.Name: commands.SendRandomMultiQuote,
 		// Add more commands here
 	}
 
@@ -32,6 +33,7 @@ var (
 	newCommands = []discord.ApplicationCommandCreate{
 		commands.AddQuoteCommandCreate,
 		commands.QuoteCommandCreate,
+		commands.MultiQuoteCommandCreate,
 		// Add more commands here
 	}
 )
@@ -84,7 +86,7 @@ func commandListener(event *events.ApplicationCommandInteractionCreate, db postg
 	if config.GuildID != event.GuildID().String() {
 		return
 	}
-	
+
 	data := event.SlashCommandInteractionData()
 	if handler, ok := commandHandlers[data.CommandName()]; ok {
 		handler(event, db)
@@ -97,7 +99,7 @@ func modalListener(event *events.ModalSubmitInteractionCreate, db postgres.Postg
 	if config.GuildID != event.GuildID().String() {
 		return
 	}
-	
+
 	if handler, ok := modalHandlers[event.Data.CustomID]; ok {
 		handler(event, db)
 	} else {


### PR DESCRIPTION
This pull request introduces a new command for retrieving multiple quotes and includes some minor improvements to existing functionality. The most important changes are summarized below:

### New Feature: Multi-Quote Command

* [`commands/multi_quote.go`](diffhunk://#diff-de22cbdcb8bd6388c4361811fc28c842374600f456aaca268250c2fb3252b3ceR1-R89): Added a new command `MultiQuoteCommandCreate` and its handler `SendRandomMultiQuote` to retrieve multiple quotes. The command supports options for ephemeral responses, the number of quotes to return, and whether to show quote IDs. (`[commands/multi_quote.goR1-R89](diffhunk://#diff-de22cbdcb8bd6388c4361811fc28c842374600f456aaca268250c2fb3252b3ceR1-R89)`)

### Improvements to Existing Functionality

* [`commands/quote.go`](diffhunk://#diff-199b875c2b0fc18839cce9824e8f7281181393e7dc88aece53bb8ba0eea5137aL39-R39): Updated the `SendRandomQuote` function to format the quote ID with a preceding ">" for better readability. (`[commands/quote.goL39-R39](diffhunk://#diff-199b875c2b0fc18839cce9824e8f7281181393e7dc88aece53bb8ba0eea5137aL39-R39)`)

### Command Registration

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R24): Registered the new `MultiQuoteCommandCreate` in the `commandHandlers` map and added it to the `newCommands` list for command creation. (`[[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R24)`, `[[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R36)`)