### PR TITLE
PATCH - Id's not rendering properly 

### DIFF
--- a/commands/multi_quote.go
+++ b/commands/multi_quote.go
@@ -55,6 +55,8 @@ func getQuotesUntilLimit(event *events.ApplicationCommandInteractionCreate, pg p
 	data := event.SlashCommandInteractionData()
 	quotes := ""
 	quoteIDs := ""
+	isCombined := false
+	slog.Info("ShowID: ", slog.Bool("showID", isShowID))
 	for i := 0; i < count; i++ {
 		message, err := pg.GetRandomQuote(data.GuildID().String())
 		if err != nil {
@@ -68,11 +70,13 @@ func getQuotesUntilLimit(event *events.ApplicationCommandInteractionCreate, pg p
 				if len(quotes+quoteIDs+"\n")+100 > 2000 {
 					quotes = quoteIDs + "\n" + quotes
 					slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+					isCombined = true
 					break
 				}
 			} else {
 				quotes = quoteIDs + "\n" + quotes
 				slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+				isCombined = true
 				break
 			}
 		} else {
@@ -80,9 +84,14 @@ func getQuotesUntilLimit(event *events.ApplicationCommandInteractionCreate, pg p
 				quotes += message.Quote + "\n"
 			} else {
 				slog.Info("Multi-Quote: ", slog.Int("QuotesLength", len(quotes)), slog.Int("QuoteCount", i))
+				isCombined = true
 				break
 			}
 		}
+	}
+
+	if !isCombined && isShowID {
+		quotes = quoteIDs + "\n" + quotes
 	}
 
 	return quotes, nil

--- a/commands/quote.go
+++ b/commands/quote.go
@@ -36,7 +36,7 @@ func SendRandomQuote(event *events.ApplicationCommandInteractionCreate, pg postg
 	showID := data.Bool("show-id")
 
 	if showID {
-		message.Quote = message.Quote + " \n> Quote Id: " + message.ID.String()
+		message.Quote = "> **Quote Id:** " + message.ID.String()+"\n\n" + message.Quote
 	}
 
 	err = event.CreateMessage(discord.NewMessageCreateBuilder().


### PR DESCRIPTION
This pull request includes changes to the `commands/multi_quote.go` and `commands/quote.go` files to enhance logging and modify the display format of quotes. The most important changes include adding a new flag for combined quotes, improving logging, and updating the quote format when the `show-id` option is enabled.

Enhancements to logging and flagging:

* [`commands/multi_quote.go`](diffhunk://#diff-de22cbdcb8bd6388c4361811fc28c842374600f456aaca268250c2fb3252b3ceR58-R59): Added an `isCombined` flag to track whether quotes are combined and enhanced logging to include this flag. [[1]](diffhunk://#diff-de22cbdcb8bd6388c4361811fc28c842374600f456aaca268250c2fb3252b3ceR58-R59) [[2]](diffhunk://#diff-de22cbdcb8bd6388c4361811fc28c842374600f456aaca268250c2fb3252b3ceR73-R96)

Display format updates:

* [`commands/quote.go`](diffhunk://#diff-199b875c2b0fc18839cce9824e8f7281181393e7dc88aece53bb8ba0eea5137aL39-R39): Modified the quote format to display the quote ID at the top when the `show-id` option is enabled.